### PR TITLE
Hot fix: Cargo.toml for NFT basic

### DIFF
--- a/cw721/on-chain-metadata/Cargo.toml
+++ b/cw721/on-chain-metadata/Cargo.toml
@@ -40,7 +40,7 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [dependencies]
-cosmwasm-std = "1.0.0-beta"
+cosmwasm-std = "~1.0.0-beta"
 cw2 = "0.11"
 cw721 = "0.11"
 cw721-base = { version = "0.11", features = ["library"] }
@@ -49,4 +49,4 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = "1.0"
 
 [dev-dependencies]
-cosmwasm-schema = "1.0.0-beta"
+cosmwasm-schema = "~1.0.0-beta"


### PR DESCRIPTION
This small change fixes the dependencies for the NFT template for archway dev cli, which is currently failing for end users.