### PR TITLE
  Adding cw-orchestrator to the Archway templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,7 @@ cargo generate --git archway-network/archway-templates.git --name PROJECT_NAME d
 
 You will now have a new folder called `PROJECT_NAME` (I hope you changed that to something else)
 containing a simple working contract and build system that you can customize.
+
+## Usage
+
+The default and increment templates include [cw-orchestrator](https://docs.rs/cw-orch/latest/cw_orch/) by default. This library allows you to unit-test, integration-test as well as interact with your contracts on-chain using a common intuitive syntax that leverages rust type-safety to assist you throughout your development process. You can find an example interface definition in the [increment/src/interface.rs](increment/src/interface.rs) file. You can also find more information in the [`cw-orch` documentation](https://orchestrator.abstract.money/).

--- a/default/Cargo.toml
+++ b/default/Cargo.toml
@@ -31,6 +31,8 @@ overflow-checks = true
 backtraces = ["cosmwasm-std/backtraces"]
 # use library feature to disable all instantiate/execute/query exports
 library = []
+# use interface feature to expose structure for contract orchestration
+interface = ["dep:cw-orch"]
 
 [package.metadata.scripts]
 optimize = """docker run --rm -v "$(pwd)":/code \
@@ -41,13 +43,16 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [dependencies]
-cosmwasm-std = "=1.0.0"
-cosmwasm-storage = "=1.0.0"
+cosmwasm-std = "1.0.0"
+cosmwasm-storage = "1.0.0"
+cosmwasm-schema = "1.0.0"
+
 cw-storage-plus = "0.14"
 cw2 = "0.14"
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = "1.0"
 
+cw-orch = { version = "0.18.1", optional = true }
+
 [dev-dependencies]
-cosmwasm-schema = "=1.0.0"

--- a/default/src/interface.rs
+++ b/default/src/interface.rs
@@ -1,0 +1,41 @@
+use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use cosmwasm_std::Empty;
+use cw_orch::{interface, prelude::*};
+
+#[interface(InstantiateMsg, ExecuteMsg, QueryMsg, Empty)]
+pub struct ContractInterface;
+
+impl<Chain: CwEnv> Uploadable for ContractInterface<Chain> {
+    /// Return the path to the wasm file corresponding to the contract
+    fn wasm(&self) -> WasmPath {
+        artifacts_dir_from_workspace!()
+            .find_wasm_path("{{crate_name}}")
+            .unwrap()
+    }
+    /// Returns a CosmWasm contract wrapper
+    fn wrapper(&self) -> Box<dyn MockContract<Empty>> {
+        Box::new(ContractWrapper::new_with_empty(
+            crate::contract::execute,
+            crate::contract::instantiate,
+            crate::contract::query,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::msg::{ExecuteMsgFns, QueryMsgFns};
+    use cw_orch::anyhow;
+
+    #[test]
+    fn contract_logic() -> anyhow::Result<()> {
+        let mock = Mock::new(&Addr::unchecked("sender"));
+        let contract = ContractInterface::new("project-name", mock);
+        contract.upload()?;
+
+        contract.instantiate(&InstantiateMsg {}, None, None)?;
+        contract.hello()?;
+        Ok(())
+    }
+}

--- a/default/src/lib.rs
+++ b/default/src/lib.rs
@@ -4,3 +4,6 @@ pub mod msg;
 pub mod state;
 
 pub use crate::error::ContractError;
+
+#[cfg(feature = "interface")]
+pub mod interface;

--- a/default/src/msg.rs
+++ b/default/src/msg.rs
@@ -5,14 +5,18 @@ use serde::{Deserialize, Serialize};
 pub struct InstantiateMsg {}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[cfg_attr(feature = "interface", derive(cw_orch::ExecuteFns))]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
     Dummy {},
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[cfg_attr(feature = "interface", derive(cw_orch::QueryFns))]
 #[serde(rename_all = "snake_case")]
+#[derive(cosmwasm_schema::QueryResponses)]
 pub enum QueryMsg {
+    #[returns(HelloResponse)]
     Hello {},
 }
 

--- a/increment/Cargo.toml
+++ b/increment/Cargo.toml
@@ -30,6 +30,8 @@ rpath = false
 backtraces = ["cosmwasm-std/backtraces"]
 # use library feature to disable all instantiate/execute/query exports
 library = []
+# use interface feature to expose structure for contract orchestration
+interface = ["dep:cw-orch"]
 
 [package.metadata.scripts]
 optimize = """docker run --rm \
@@ -53,5 +55,8 @@ schemars = "0.8.12"
 serde = { version = "1.0.183", default-features = false, features = ["derive"] }
 thiserror = "1.0.44"
 
+cw-orch = { version = "0.18.1", optional = true }
+
 [dev-dependencies]
 cw-multi-test = "0.17.0"
+{{project-name}} = {path = ".", features=["interface"]}

--- a/increment/src/interface.rs
+++ b/increment/src/interface.rs
@@ -1,0 +1,45 @@
+use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use cosmwasm_std::Empty;
+use cw_orch::{interface, prelude::*};
+
+#[interface(InstantiateMsg, ExecuteMsg, QueryMsg, Empty)]
+pub struct ContractInterface;
+
+impl<Chain: CwEnv> Uploadable for ContractInterface<Chain> {
+    /// Return the path to the wasm file corresponding to the contract
+    fn wasm(&self) -> WasmPath {
+        artifacts_dir_from_workspace!()
+            .find_wasm_path("{{crate_name}}")
+            .unwrap()
+    }
+    /// Returns a CosmWasm contract wrapper
+    fn wrapper(&self) -> Box<dyn MockContract<Empty>> {
+        Box::new(ContractWrapper::new_with_empty(
+            crate::contract::execute,
+            crate::contract::instantiate,
+            crate::contract::query,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::msg::{ExecuteMsgFns, QueryMsgFns};
+    use cw_orch::anyhow;
+
+    #[test]
+    fn contract_logic() -> anyhow::Result<()> {
+        let mock = Mock::new(&Addr::unchecked("sender"));
+        let contract = ContractInterface::new("project-name", mock);
+        contract.upload()?;
+
+        contract.instantiate(&InstantiateMsg { count: 7 }, None, None)?;
+        assert_eq!(contract.get_count()?.count, 7);
+
+        contract.increment()?;
+        assert_eq!(contract.get_count()?.count, 8);
+
+        Ok(())
+    }
+}

--- a/increment/src/lib.rs
+++ b/increment/src/lib.rs
@@ -6,3 +6,6 @@ pub mod helpers;
 pub mod state;
 
 pub use crate::error::ContractError;
+
+#[cfg(feature = "interface")]
+pub mod interface;

--- a/increment/src/msg.rs
+++ b/increment/src/msg.rs
@@ -6,6 +6,7 @@ pub struct InstantiateMsg {% raw %}{{% endraw %}{% unless version == "minimal" %
 {% endunless %}}
 
 #[cw_serde]
+#[cfg_attr(feature = "interface", derive(cw_orch::ExecuteFns))]
 pub enum ExecuteMsg {% raw %}{{% endraw %}{% unless version == "minimal" %}
     Increment {},
     Reset { count: i32 },
@@ -13,6 +14,7 @@ pub enum ExecuteMsg {% raw %}{{% endraw %}{% unless version == "minimal" %}
 
 #[cw_serde]
 #[derive(QueryResponses)]
+#[cfg_attr(feature = "interface", derive(cw_orch::QueryFns))]
 pub enum QueryMsg {% raw %}{{% endraw %}{% unless version == "minimal" %}
     // GetCount returns the current count as a json-encoded number
     #[returns(GetCountResponse)]


### PR DESCRIPTION

This PR aims at adding cw-orchestrator directly into the Archway templates.

You can find the docs here : https://orchestrator.abstract.money/

This library empowers users with their smart-contracts and allows them to script, test and more using a single intuitive syntax and without leaving the Rust programming language.

With this template, cw-orch integration has never been easier. The generated interface is available directly inside the template tests. An example test syntax can be found in the increment/src/interface.rs file.
